### PR TITLE
Add privacy policy and terms & conditions pages

### DIFF
--- a/src/app/privacy-policy/page.js
+++ b/src/app/privacy-policy/page.js
@@ -1,0 +1,125 @@
+import { getSiteInformation } from '../../../lib/contentful'
+import Layout from '../../components/layout'
+import SEO from '../../components/seo'
+
+export const metadata = {
+  title: 'Privacy Policy | Michael Lunzer',
+  description: 'Privacy policy for michaellunzer.com, covering SMS messaging and personal data handling.',
+}
+
+export default async function PrivacyPolicyPage() {
+  let siteInfo = null
+  try {
+    siteInfo = await getSiteInformation()
+  } catch (error) {
+    console.error('Error loading site info:', error)
+  }
+
+  return (
+    <Layout header="privacy" siteInfo={siteInfo}>
+      <SEO
+        title="Privacy Policy"
+        keywords={['Privacy Policy', 'Michael Lunzer', 'SMS']}
+        siteInfo={siteInfo}
+      />
+      <div className="site-container">
+        <div className="container">
+          <div className="row">
+            <div className="col-sm-12">
+              <div style={{ maxWidth: '800px', margin: '60px auto', padding: '0 20px 60px' }}>
+                <h1>Privacy Policy</h1>
+                <p><strong>Effective Date:</strong> May 5, 2026<br /><strong>Last Updated:</strong> May 5, 2026</p>
+                <hr />
+
+                <h2>1. Overview</h2>
+                <p>This Privacy Policy describes how Michael Lunzer (&ldquo;I,&rdquo; &ldquo;me,&rdquo; or &ldquo;my&rdquo;) collects, uses, and protects your personal information when you interact with me via SMS text messaging or through my website at <a href="https://michaellunzer.com">https://michaellunzer.com</a>.</p>
+
+                <hr />
+
+                <h2>2. Information I Collect</h2>
+                <p>I may collect the following information from you:</p>
+                <ul>
+                  <li><strong>Mobile phone number</strong> &mdash; when you opt in to receive SMS messages</li>
+                  <li><strong>Name and contact details</strong> &mdash; when provided through a website form or direct communication</li>
+                  <li><strong>Message content</strong> &mdash; the content of SMS messages you send to me as part of two-way customer support conversations</li>
+                </ul>
+
+                <hr />
+
+                <h2>3. How I Use Your Information</h2>
+                <p>I use your information solely to:</p>
+                <ul>
+                  <li>Respond to your customer support inquiries via SMS</li>
+                  <li>Send you information you have explicitly requested</li>
+                  <li>Maintain records of our communications for service quality purposes</li>
+                </ul>
+
+                <hr />
+
+                <h2>4. SMS Messaging</h2>
+
+                <h3>Opt-In</h3>
+                <p>You may opt in to receive SMS messages from me in one of two ways:</p>
+                <ul>
+                  <li><strong>Website form:</strong> By submitting your mobile number through the opt-in form at <a href="https://michaellunzer.com">https://michaellunzer.com</a></li>
+                  <li><strong>Text keyword:</strong> By texting a keyword to my number to initiate contact</li>
+                </ul>
+                <p>By opting in, you consent to receive SMS messages related to customer support and any topics you have inquired about.</p>
+
+                <h3>Opt-Out</h3>
+                <p>You may opt out of SMS messages at any time by replying <strong>STOP</strong> to any message. After opting out, you will receive a single confirmation message and no further messages will be sent unless you opt in again.</p>
+                <p>To get help, reply <strong>HELP</strong> to any message.</p>
+
+                <h3>Message Frequency</h3>
+                <p>Message frequency varies based on your support needs and the nature of your inquiry.</p>
+
+                <h3>Message and Data Rates</h3>
+                <p>Standard message and data rates may apply depending on your mobile carrier and plan.</p>
+
+                <hr />
+
+                <h2>5. Sharing of Information</h2>
+                <p><strong>Your mobile phone number and any information collected through SMS will not be shared with third parties or affiliates for marketing or promotional purposes.</strong></p>
+                <p>I do not sell, rent, or trade your personal information. I will not share your information with any third party except:</p>
+                <ul>
+                  <li>As required by law or legal process</li>
+                  <li>To protect my rights or the safety of others</li>
+                  <li>With service providers strictly necessary to deliver the SMS service (e.g., Twilio as my SMS platform provider), who are bound by their own privacy and data protection obligations</li>
+                </ul>
+
+                <hr />
+
+                <h2>6. Data Retention</h2>
+                <p>I retain your information only as long as necessary to fulfill the purposes described in this policy or as required by law. You may request deletion of your information at any time by contacting me directly.</p>
+
+                <hr />
+
+                <h2>7. Your Rights</h2>
+                <p>You have the right to:</p>
+                <ul>
+                  <li>Request access to the personal information I hold about you</li>
+                  <li>Request correction of inaccurate information</li>
+                  <li>Request deletion of your information</li>
+                  <li>Opt out of SMS communications at any time by replying STOP</li>
+                </ul>
+
+                <hr />
+
+                <h2>8. Contact</h2>
+                <p>If you have any questions about this Privacy Policy or how your information is handled, please contact me at:</p>
+                <p>
+                  <strong>Michael Lunzer</strong><br />
+                  Website: <a href="https://michaellunzer.com">https://michaellunzer.com</a>
+                </p>
+
+                <hr />
+
+                <p><em>This policy applies to SMS communications facilitated through Twilio&rsquo;s A2P 10DLC messaging platform.</em></p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/src/app/terms/page.js
+++ b/src/app/terms/page.js
@@ -1,0 +1,135 @@
+import { getSiteInformation } from '../../../lib/contentful'
+import Layout from '../../components/layout'
+import SEO from '../../components/seo'
+
+export const metadata = {
+  title: 'Terms and Conditions | Michael Lunzer',
+  description: 'Terms and conditions for michaellunzer.com, covering SMS messaging and acceptable use.',
+}
+
+export default async function TermsPage() {
+  let siteInfo = null
+  try {
+    siteInfo = await getSiteInformation()
+  } catch (error) {
+    console.error('Error loading site info:', error)
+  }
+
+  return (
+    <Layout header="terms" siteInfo={siteInfo}>
+      <SEO
+        title="Terms and Conditions"
+        keywords={['Terms and Conditions', 'Michael Lunzer', 'SMS']}
+        siteInfo={siteInfo}
+      />
+      <div className="site-container">
+        <div className="container">
+          <div className="row">
+            <div className="col-sm-12">
+              <div style={{ maxWidth: '800px', margin: '60px auto', padding: '0 20px 60px' }}>
+                <h1>Terms and Conditions</h1>
+                <p><strong>Effective Date:</strong> May 5, 2026<br /><strong>Last Updated:</strong> May 5, 2026</p>
+                <hr />
+
+                <h2>1. Acceptance of Terms</h2>
+                <p>By accessing my website at <a href="https://michaellunzer.com">https://michaellunzer.com</a> or opting in to receive SMS messages from me, you agree to these Terms and Conditions. If you do not agree, please do not use my services or opt in to SMS communications.</p>
+
+                <hr />
+
+                <h2>2. SMS Messaging Service</h2>
+
+                <h3>Description</h3>
+                <p>I offer a two-way SMS customer support service that allows you to communicate with me directly via text message. This service is intended to help answer questions, provide information, and resolve support inquiries.</p>
+
+                <h3>Eligibility</h3>
+                <p>By opting in to SMS messaging, you confirm that:</p>
+                <ul>
+                  <li>You are the account holder or have the account holder&rsquo;s permission to use the mobile number provided</li>
+                  <li>You are 18 years of age or older</li>
+                  <li>You are located in the United States or Canada</li>
+                </ul>
+
+                <h3>Opt-In</h3>
+                <p>You may opt in to receive SMS messages in one of two ways:</p>
+                <ul>
+                  <li><strong>Website form:</strong> By submitting your mobile number through the opt-in form at <a href="https://michaellunzer.com">https://michaellunzer.com</a></li>
+                  <li><strong>Text keyword:</strong> By texting a keyword to my number</li>
+                </ul>
+                <p>By opting in, you expressly consent to receive text messages from me related to customer support.</p>
+
+                <h3>Opt-Out</h3>
+                <p>You may opt out at any time by replying <strong>STOP</strong> to any message. You will receive a single confirmation message and no further messages will be sent. To re-subscribe, opt in again through any available opt-in method.</p>
+
+                <h3>Help</h3>
+                <p>Reply <strong>HELP</strong> to any message for assistance, or contact me directly through my website.</p>
+
+                <h3>Message Frequency</h3>
+                <p>Message frequency varies based on the nature of your inquiry and support needs.</p>
+
+                <h3>Costs</h3>
+                <p>Message and data rates may apply. I am not responsible for any charges applied by your mobile carrier.</p>
+
+                <hr />
+
+                <h2>3. Acceptable Use</h2>
+                <p>When using my SMS service or website, you agree not to:</p>
+                <ul>
+                  <li>Use the service for any unlawful purpose</li>
+                  <li>Send abusive, threatening, or harassing messages</li>
+                  <li>Impersonate any person or entity</li>
+                  <li>Attempt to gain unauthorized access to any system or network</li>
+                  <li>Use the service to transmit spam or unsolicited communications</li>
+                </ul>
+                <p>I reserve the right to discontinue SMS service to any user who violates these terms.</p>
+
+                <hr />
+
+                <h2>4. Intellectual Property</h2>
+                <p>All content on <a href="https://michaellunzer.com">https://michaellunzer.com</a>, including text, graphics, and other materials, is owned by Michael Lunzer and may not be reproduced, distributed, or used without prior written permission.</p>
+
+                <hr />
+
+                <h2>5. Disclaimer of Warranties</h2>
+                <p>My services are provided &ldquo;as is&rdquo; without warranties of any kind, either express or implied. I do not warrant that:</p>
+                <ul>
+                  <li>The service will be uninterrupted or error-free</li>
+                  <li>SMS messages will be delivered instantaneously or at all times</li>
+                  <li>The website will be free from viruses or other harmful components</li>
+                </ul>
+
+                <hr />
+
+                <h2>6. Limitation of Liability</h2>
+                <p>To the fullest extent permitted by law, Michael Lunzer shall not be liable for any indirect, incidental, special, or consequential damages arising out of your use of &mdash; or inability to use &mdash; the SMS service or website, including any damages resulting from delayed or undelivered messages.</p>
+
+                <hr />
+
+                <h2>7. Privacy</h2>
+                <p>Your use of this service is also governed by my <a href="/privacy-policy">Privacy Policy</a>, which is incorporated into these Terms by reference.</p>
+
+                <hr />
+
+                <h2>8. Changes to These Terms</h2>
+                <p>I may update these Terms and Conditions from time to time. Changes will be posted at <a href="https://michaellunzer.com/terms">https://michaellunzer.com/terms</a> with an updated effective date. Continued use of the service after changes are posted constitutes your acceptance of the revised terms.</p>
+
+                <hr />
+
+                <h2>9. Governing Law</h2>
+                <p>These Terms are governed by the laws of the State of California, without regard to its conflict of law provisions.</p>
+
+                <hr />
+
+                <h2>10. Contact</h2>
+                <p>If you have any questions about these Terms and Conditions, please contact me at:</p>
+                <p>
+                  <strong>Michael Lunzer</strong><br />
+                  Website: <a href="https://michaellunzer.com">https://michaellunzer.com</a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/privacy-policy` page covering SMS data collection, opt-in/opt-out, Twilio A2P 10DLC, and data retention
- Adds `/terms` page covering SMS service eligibility, acceptable use, disclaimers, and governing law
- Both pages follow the existing `Layout` + `SEO` component pattern and handle Contentful errors gracefully

## Test plan

- [ ] Visit `michaellunzer.com/privacy-policy` and confirm all sections render correctly
- [ ] Visit `michaellunzer.com/terms` and confirm all sections render correctly
- [ ] Confirm the Privacy Policy link in Terms section 7 navigates to `/privacy-policy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)