### PR TITLE
Fix feature image overflowing onto blog post text

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -138,7 +138,8 @@ pre{margin-bottom:0}
 .work-list .item .inner .name{position:absolute;bottom:5px;left:0;right:0;width:100%;background:#333333b3;padding:10px 20px;color:#fff;text-shadow:1px 1px 4px #333}
 .photos-item .gatsby-image-wrapper{width:100%;height:200px}
 .site-container{padding:100px 0 20px 0}
-.blog-post .feature-img{width:100%;height:600px}
+.blog-post .feature-img{width:100%;height:600px;overflow:hidden}
+.blog-post .feature-img img{width:100%;height:100%;-o-object-fit:cover;object-fit:cover;display:block}
 .blog-post .details .date{margin-bottom:40px;display:block}
 .blog-post .details{padding:20px 0}
 .post-social{margin-bottom:40px}


### PR DESCRIPTION
## What

Constrains the blog post feature image to its container so it stops spilling over the post title and body copy.

```css
.blog-post .feature-img{width:100%;height:600px;overflow:hidden}
.blog-post .feature-img img{width:100%;height:100%;object-fit:cover;display:block}
```

## Why

`.blog-post .feature-img` is a fixed-height box (600px desktop, 400px under 991px, 300px under 568px), but the `<img>` inside had no height rule of its own — only the global `img{max-width:100%}`. The browser scaled the image to the container's width and let its height follow the 1500×800 intrinsic aspect ratio, ignoring the 600px box entirely.

On a wide viewport the container is 1296px, so the image rendered **691px tall inside a 600px box** — 91px of image spilling out over `.details`.

The `objectFit: 'cover'` already passed to `next/image` did nothing here, because `object-fit` only takes effect once the element's box is actually constrained. Adding the explicit `height:100%` is what makes it work.

This affects every blog post, not just one.

## Verification

The local dev server would not start in this environment (`next dev` produces no output and never binds a port under Node v26.7.0), so I verified against the live site in a browser — injecting the exact rule from this PR and measuring geometry at a 1500px viewport:

| | image height | box height | overlap onto title |
|---|---|---|---|
| Before | 691px | 600px | **91px** |
| After | 600px | 600px | 0px |

## Notes for the reviewer

- The existing responsive heights (400px / 300px) inherit this automatically — no breakpoint changes needed.
- Because the image now crops to a 1.92:1 box instead of showing at its natural 1.875:1 ratio, cropping is very slightly tighter than the intrinsic image. `object-position: 50% 50%` (already set inline) keeps it centered.
- `.project-post .feature-img` has no height rule, so project pages were never affected and are left alone.
- Scoped deliberately to this one fix. Other in-progress work in the local tree (Share component removal, a Spotify playlist change, `yarn.lock`) is **not** included here.