### PR TITLE
Stop cropping blog and project feature images

### DIFF
--- a/src/app/blogs/[slug]/page.js
+++ b/src/app/blogs/[slug]/page.js
@@ -32,6 +32,15 @@ export default async function BlogPost({ params }) {
     notFound()
   }
 
+  // Contentful knows each asset's real dimensions; hard-coding a ratio here
+  // made next/image letterbox and crop images that were not that shape.
+  const featureImageDetails =
+    blog.fields.featureImage?.fields?.file?.details?.image
+  const featureImageSize = {
+    width: featureImageDetails?.width || 1500,
+    height: featureImageDetails?.height || 800,
+  }
+
   const siteurl = siteInfo?.fields?.siteUrl || 'https://www.michaellunzer.com'
   const twitterHandle = siteInfo?.fields?.twiteerHandle
   const socialConfig = {
@@ -61,10 +70,9 @@ export default async function BlogPost({ params }) {
               <Image
                 src={`https:${blog.fields.featureImage.fields.file.url}`}
                 alt={blog.fields.title}
-                width={1500}
-                height={800}
+                width={featureImageSize.width}
+                height={featureImageSize.height}
                 className="img-fluid"
-                style={{ objectFit: 'cover', objectPosition: '50% 50%' }}
               />
             </div>
           ) : (

--- a/src/app/projects/[slug]/page.js
+++ b/src/app/projects/[slug]/page.js
@@ -32,6 +32,15 @@ export default async function ProjectPost({ params }) {
       notFound()
     }
 
+    // Contentful knows each asset's real dimensions; hard-coding a ratio here
+    // made next/image letterbox and crop images that were not that shape.
+    const featureImageDetails =
+      project.fields.featureImage?.fields?.file?.details?.image
+    const featureImageSize = {
+      width: featureImageDetails?.width || 1500,
+      height: featureImageDetails?.height || 800,
+    }
+
     const siteurl = siteInfo?.fields?.siteUrl || 'https://www.michaellunzer.com'
     const twitterHandle = siteInfo?.fields?.twiteerHandle
     const socialConfig = {
@@ -61,10 +70,9 @@ export default async function ProjectPost({ params }) {
                 <Image
                   src={`https:${project.fields.featureImage.fields.file.url}`}
                   alt={project.fields.title}
-                  width={1500}
-                  height={800}
+                  width={featureImageSize.width}
+                  height={featureImageSize.height}
                   className="img-fluid"
-                  style={{ objectFit: 'cover', objectPosition: '50% 50%' }}
                 />
               </div>
             ) : (

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -138,8 +138,10 @@ pre{margin-bottom:0}
 .work-list .item .inner .name{position:absolute;bottom:5px;left:0;right:0;width:100%;background:#333333b3;padding:10px 20px;color:#fff;text-shadow:1px 1px 4px #333}
 .photos-item .gatsby-image-wrapper{width:100%;height:200px}
 .site-container{padding:100px 0 20px 0}
-.blog-post .feature-img{width:100%;height:600px;overflow:hidden}
-.blog-post .feature-img img{width:100%;height:100%;-o-object-fit:cover;object-fit:cover;display:block}
+.blog-post .feature-img{width:100%}
+.blog-post .feature-img img{width:100%;height:auto;display:block}
+.project-post .feature-img{width:100%}
+.project-post .feature-img img{width:100%;height:auto;display:block}
 .blog-post .details .date{margin-bottom:40px;display:block}
 .blog-post .details{padding:20px 0}
 .post-social{margin-bottom:40px}
@@ -199,7 +201,6 @@ pre{margin-bottom:0}
     .blogs-list .item:nth-child(1) .no-image,.blogs-list .item:nth-child(2) .no-image{height:200px!important}
     .work-list .item{width:50%}
     .photos-page-list .item{width:50%}
-    .blog-post .feature-img{height:400px}
 }
 @media only screen and (max-width:767px){
     .site-header .header-main .logo{width:10%;width:calc(15% - 30px)}
@@ -226,7 +227,6 @@ pre{margin-bottom:0}
     .blogs-list .item{width:100%!important}
     .banner .banner-details h1{font-size:34px;margin-bottom:10px}
     .banner .banner-details span{font-size:19px;margin-bottom:0}
-    .blog-post .feature-img{height:300px}
     .post-social button{margin-bottom:10px;padding:5px 10px!important;font-size:12px!important}
     .blogs-list .item .inner .details .date{font-size:12px}
     .blogs-list .item .inner .details .title{font-size:20px}


### PR DESCRIPTION
Follow-up to #50. That PR stopped the feature image overflowing onto the post text, but it did so by pinning the image into a fixed 600px band with `object-fit: cover` — which made an already-existing crop noticeably worse. This removes the cropping entirely.

## Root cause

Both `[slug]/page.js` files hard-coded the same intrinsic size for every feature image:

```jsx
width={1500}
height={800}   // 1.875 — a ratio none of the actual images have
```

Measured from the live site, the real assets are:

| Ratio | Assets |
|---|---|
| 0.75 | `esphome-stepper-motor-heater-controller` (960×1280, **portrait**) |
| 1.33 | `picocart64`, `esphome-sniffer-aqi-sensor` |
| 1.41 | `new-website` |
| 1.50 | `upgrading-my-trash-mac-pro` (1536×1024), `my-digital-backup-strategy`, `2020-pandemic-tp-analysis` |
| 1.78 | 5 blog posts + 4 projects (the most common shape) |
| **1.875** | **none** |

`next/image` builds the element box from the declared width/height, so every image was forced into a 1.875 box and `object-fit: cover` cropped whatever didn't fit. On the Mac Pro post that removed 132px from the top and bottom. The portrait project image lost roughly 60% of its height.

## Change

- Read each asset's real dimensions from Contentful (`file.details.image`) and pass those to `next/image`, falling back to the old constants if the field is missing.
- Drop `objectFit: 'cover'` / `objectPosition` — with correct dimensions there is nothing to crop.
- Let the box height follow the image: `.feature-img img{width:100%;height:auto}`, and remove the fixed 600/400/300px heights.

The overflow bug #50 fixed stays fixed: the image can no longer spill onto the text because its height is now its own, not a box it has to fit inside.

Applied to projects as well as blogs — same markup, same defect, and projects had the worst case of it.

## Verification

Measured in-browser on the live Mac Pro post at 1485px viewport, simulating this build:

| | element box | cropped off top |
|---|---|---|
| Live today | 1296×600 | **132px** |
| This PR | 1296×864 | **0px** |

Overflow past the container and overlap onto `.details` both measure 0px after. Confirmed visually that the poster's title and the trash can — previously cut off at top and bottom — are both fully visible. Both modified files parse clean as JSX.

## Reviewer note

Banner height now varies per post instead of being a uniform 600px band: about 729px for the 16:9 images and up to 973px for `picocart64` at desktop width. That is the deliberate trade for never cropping, chosen over biasing the crop toward the top. If the taller images feel overwhelming, a `max-height` cap can be layered on later without reintroducing the hard-coded ratio.